### PR TITLE
Enable jekyll site variables for HEAD meta tags.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@
 url: http://yoursite.com
 title: Your Awesome Site
 email: your-email@domain.com
+author: Your Name
 description: > # "Write an awesome description for your new site here. 
   You can edit this line in _config.yml. It will appear in your document 
   head meta (for Google search results) and in your feed.xml site 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,8 +3,8 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="">
-    <meta name="author" content="">
+    <meta name="description" content="{{ site.description }}">
+    <meta name="author" content="{{ site.author }}">
 
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
 


### PR DESCRIPTION
This will use the site config to set the Author and Description