### PR TITLE
Move post description to content.

### DIFF
--- a/_includes/page_content.html
+++ b/_includes/page_content.html
@@ -11,7 +11,7 @@
                     <hr class="section-heading-spacer">
                     <div class="clearfix"></div>
                     <h2 class="section-heading">{{ post.title }}</h2>
-                    {{ post.description }}
+                    <div class="lead">{{ post.content }}</div>
                 </div>
                 <div class="col-lg-5 col-lg-offset-2 col-sm-6">
                     <img class="img-responsive" src="img/services/{{ post.img }}" alt="">
@@ -34,7 +34,7 @@
                     <hr class="section-heading-spacer">
                     <div class="clearfix"></div>
                     <h2 class="section-heading">{{ post.title }}</h2>
-                    {{ post.description }}
+                    <div class="lead">{{ post.content }}</div>
                 </div>
                 <div class="col-lg-5 col-sm-pull-6  col-sm-6">
                   <img class="img-responsive" src="img/services/{{ post.img }}" alt="">

--- a/_posts/2014-09-21-services-1.markdown
+++ b/_posts/2014-09-21-services-1.markdown
@@ -4,9 +4,5 @@ img: ipad.png
 category: Services
 title: Death to the Stock Photo:<br>Special Thanks
 description: |
-  <p class="lead">A special thanks to <a target="_blank"
-  href="http://join.deathtothestockphoto.com/">Death to the Stock
-  Photo</a> for providing the photographs that you see in this template.
-  Visit their website to become a member!</p>
-
 ---
+  A special thanks to [Death to the Stock Photo](http://join.deathtothestockphoto.com/) for providing the photographs that you see in this template.  Visit their website to become a member!

--- a/_posts/2014-09-22-services-2.markdown
+++ b/_posts/2014-09-22-services-2.markdown
@@ -4,10 +4,7 @@ img: dog.png
 category: Services
 title: 3D Device Mockups<br>by PSDCovers
 description: |
-  <p class="lead">Turn your 2D designs into high quality, 3D
-  product shots in seconds using free Photoshop actions by <a
-  target="_blank" href="http://www.psdcovers.com/">PSDCovers</a>! Visit
-  their website to download some of their awesome, free photoshop
-  actions!</p>
-
 ---
+  Turn your 2D designs into high quality, 3D
+  product shots in seconds using free Photoshop actions by [PSDCovers](http://www.psdcovers.com/)! Visit
+  their website to download some of their awesome, free photoshop actions!

--- a/_posts/2014-09-23-services-3.markdown
+++ b/_posts/2014-09-23-services-3.markdown
@@ -4,9 +4,5 @@ img: phones.png
 category: Services
 title: Google Web Fonts and<br>Font Awesome Icons
 description: |
-  <p class="lead">This template features the 'Lato' font,
-  part of the <a target="_blank" href="http://www.google.com/fonts">Google
-  Web Font library</a>, as well as <a target="_blank"
-  href="http://fontawesome.io">icons from Font Awesome</a>.</p>
-
 ---
+This template features the 'Lato' font, part of the [Google Web Font library](http://www.google.com/fonts), as well as [icons from Font Awesome](http://fontawesome.io).


### PR DESCRIPTION
This allows Markdown to be used. Move HTML markup to templates instead of each post.

You can reject this one if you feel the need to keep the subtitle in the description, but the HTML should be in the page_content template instead of post.