### PR TITLE
only display posts in the 'Services' category

### DIFF
--- a/_includes/page_content.html
+++ b/_includes/page_content.html
@@ -1,6 +1,6 @@
 <section id="services">
 <!-- Page Content -->
-{% for post in site.posts reversed %}
+{% for post in site.categories["Services"] reversed %}
   {% capture thecycle %}{% cycle 'odd', 'even' %}{% endcapture %}
     {% if thecycle == 'odd' %}
     <div class="content-section-a">


### PR DESCRIPTION
Hi, thanks for this awesome theme. This revision restricts the posts which show up on the landing page to only those marked with `category: Services` in the yml front-matter. Since all existing starter posts are categorized this way, this change doesn't affect the current landing page layout.

You might consider this revision if you would like to move in the direction of greater extensibility.
